### PR TITLE
added remote API to the prod backend for start command

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -23,7 +23,7 @@
     "redux-thunk": "^2.2.0"
   },
   "scripts": {
-    "start": "react-scripts start",
+    "start": "REACT_APP_API_BASE_URL=https://www.arrow-tracker.com/api react-scripts start",
     "start-local": "REACT_APP_API_BASE_URL=http://localhost:8080/api react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",


### PR DESCRIPTION
Most of the time client side changes don't need a local server/mongo running.
So I added remote API url to the npm start command.

## Test plan

- cd client
- npm run start
- open dev console, confirm API requests are sent to www.arrow-tracker.com